### PR TITLE
Add analytics metrics endpoint

### DIFF
--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Appointment } from '../appointments/entities/appointment.entity';
+import { Service } from '../services/entities/service.entity';
+import { Staff } from '../staff/entities/staff.entity';
+
+interface StaffMetrics {
+  appointmentCount: number;
+  revenue: number;
+  mostBookedService: {
+    serviceId: string;
+    name: string;
+    count: number;
+  } | null;
+  utilizationRate: number;
+}
+
+@Injectable()
+export class AnalyticsService {
+  constructor(
+    @InjectRepository(Appointment)
+    private readonly appointmentRepository: Repository<Appointment>,
+    @InjectRepository(Service)
+    private readonly serviceRepository: Repository<Service>,
+    @InjectRepository(Staff)
+    private readonly staffRepository: Repository<Staff>,
+  ) {}
+
+  async getStaffMetrics(staffId: string): Promise<StaffMetrics> {
+    const staff = await this.staffRepository.findOne({ where: { id: staffId } });
+    if (!staff) {
+      throw new NotFoundException(`Staff member with ID ${staffId} not found`);
+    }
+
+    const baseQuery = this.appointmentRepository
+      .createQueryBuilder('appointment')
+      .leftJoin('appointment.service', 'service')
+      .where('appointment.staffId = :staffId', { staffId });
+
+    const appointmentCount = await baseQuery.getCount();
+
+    const revenueResult = await baseQuery
+      .select('SUM(service.price)', 'revenue')
+      .getRawOne<{ revenue: string }>();
+    const revenue = parseFloat(revenueResult?.revenue ?? '0');
+
+    const mostBooked = await this.appointmentRepository
+      .createQueryBuilder('appointment')
+      .leftJoin('appointment.service', 'service')
+      .select('appointment.serviceId', 'serviceId')
+      .addSelect('service.name', 'name')
+      .addSelect('COUNT(*)', 'count')
+      .where('appointment.staffId = :staffId', { staffId })
+      .groupBy('appointment.serviceId')
+      .addGroupBy('service.name')
+      .orderBy('count', 'DESC')
+      .limit(1)
+      .getRawOne<{ serviceId: string; name: string; count: string }>();
+
+    const mostBookedService =
+      mostBooked && mostBooked.serviceId
+        ? {
+            serviceId: mostBooked.serviceId,
+            name: mostBooked.name,
+            count: parseInt(mostBooked.count, 10),
+          }
+        : null;
+
+    const durationResult = await baseQuery
+      .select('SUM(service.durationMinutes)', 'duration')
+      .getRawOne<{ duration: string }>();
+    const bookedMinutes = parseInt(durationResult?.duration ?? '0', 10);
+
+    const workingMinutes = staff.workingHours.reduce((dayAcc, day) => {
+      return (
+        dayAcc +
+        day.slots.reduce((slotAcc, slot) => {
+          const [sh, sm] = slot.start.split(':').map(Number);
+          const [eh, em] = slot.end.split(':').map(Number);
+          return slotAcc + (eh * 60 + em - (sh * 60 + sm));
+        }, 0)
+      );
+    }, 0);
+
+    const utilizationRate = workingMinutes
+      ? bookedMinutes / workingMinutes
+      : 0;
+
+    return {
+      appointmentCount,
+      revenue,
+      mostBookedService,
+      utilizationRate,
+    };
+  }
+}

--- a/src/staff/staff.controller.ts
+++ b/src/staff/staff.controller.ts
@@ -18,11 +18,18 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../shared/enums/user-role.enum';
+import { AnalyticsService } from '../analytics/analytics.service';
 
 @ApiTags('staff')
 @Controller('staff')
 export class StaffController {
-  constructor(private readonly staffService: StaffService) {}
+  constructor(
+    private readonly staffService: StaffService,
+    private readonly analyticsService: AnalyticsService,
+  ) {}
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
@@ -54,6 +61,16 @@ export class StaffController {
   @ApiResponse({ status: 404, description: 'Staff member not found.' })
   findOne(@Param('id') id: string) {
     return this.staffService.findOne(id);
+  }
+
+  @Get(':id/metrics')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(UserRole.OWNER)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get analytics for a staff member (owner only)' })
+  @ApiResponse({ status: 200, description: 'Return metrics for the staff member.' })
+  getMetrics(@Param('id') id: string) {
+    return this.analyticsService.getStaffMetrics(id);
   }
 
   @Get('salon/:salonId')

--- a/src/staff/staff.module.ts
+++ b/src/staff/staff.module.ts
@@ -3,11 +3,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { StaffService } from './staff.service';
 import { StaffController } from './staff.controller';
 import { Staff } from './entities/staff.entity';
+import { Appointment } from '../appointments/entities/appointment.entity';
+import { Service } from '../services/entities/service.entity';
+import { AnalyticsService } from '../analytics/analytics.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Staff])],
+  imports: [
+    TypeOrmModule.forFeature([Staff, Appointment, Service]),
+  ],
   controllers: [StaffController],
-  providers: [StaffService],
-  exports: [StaffService],
+  providers: [StaffService, AnalyticsService],
+  exports: [StaffService, AnalyticsService],
 })
 export class StaffModule {}


### PR DESCRIPTION
## Summary
- implement `AnalyticsService` for staff metrics
- expose `GET /staff/:id/metrics` secured for owners

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: nest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844077694b4832b81b98c55dd323c9d