### PR TITLE
Add salon calendar endpoint

### DIFF
--- a/src/salons/calendar.service.ts
+++ b/src/salons/calendar.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { AppointmentsService } from '../appointments/appointments.service';
+import { StaffService } from '../staff/staff.service';
+
+export type CalendarView = 'day' | 'week' | 'month';
+
+@Injectable()
+export class CalendarService {
+  constructor(
+    private readonly appointmentsService: AppointmentsService,
+    private readonly staffService: StaffService,
+  ) {}
+
+  async getSalonCalendar(salonId: string, view: CalendarView) {
+    const [staffMembers, appointments] = await Promise.all([
+      this.staffService.findBySalon(salonId),
+      this.appointmentsService.findBySalon(salonId),
+    ]);
+
+    const now = new Date();
+    let rangeStart: Date;
+    let rangeEnd: Date;
+
+    if (view === 'day') {
+      rangeStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      rangeEnd = new Date(rangeStart);
+      rangeEnd.setDate(rangeEnd.getDate() + 1);
+    } else if (view === 'week') {
+      rangeStart = new Date(now);
+      rangeStart.setDate(now.getDate() - now.getDay());
+      rangeStart.setHours(0, 0, 0, 0);
+      rangeEnd = new Date(rangeStart);
+      rangeEnd.setDate(rangeEnd.getDate() + 7);
+    } else {
+      rangeStart = new Date(now.getFullYear(), now.getMonth(), 1);
+      rangeEnd = new Date(
+        rangeStart.getFullYear(),
+        rangeStart.getMonth() + 1,
+        1,
+      );
+    }
+
+    const filteredAppointments = appointments.filter((a) => {
+      const date = new Date(`${a.date}T${a.time}`);
+      return date >= rangeStart && date < rangeEnd;
+    });
+
+    return {
+      salonId,
+      view,
+      staffSchedules: staffMembers.map((s) => ({
+        id: s.id,
+        name: s.name,
+        workingHours: s.workingHours,
+        appointments: filteredAppointments.filter((a) => a.staffId === s.id),
+      })),
+    };
+  }
+}

--- a/src/salons/salons.controller.ts
+++ b/src/salons/salons.controller.ts
@@ -8,8 +8,10 @@ import {
   Delete,
   UseGuards,
   Request,
+  Query,
 } from '@nestjs/common';
 import { SalonsService } from './salons.service';
+import { CalendarService, CalendarView } from './calendar.service';
 import { CreateSalonDto } from './dto/create-salon.dto';
 import { UpdateSalonDto } from './dto/update-salon.dto';
 import {
@@ -19,11 +21,17 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../shared/enums/user-role.enum';
 
 @ApiTags('salons')
 @Controller('salons')
 export class SalonsController {
-  constructor(private readonly salonsService: SalonsService) {}
+  constructor(
+    private readonly salonsService: SalonsService,
+    private readonly calendarService: CalendarService,
+  ) {}
 
   @Post()
   @ApiOperation({ summary: 'Create a new salon' })
@@ -62,6 +70,21 @@ export class SalonsController {
   @ApiResponse({ status: 404, description: 'Salon not found.' })
   findAvailability(@Param('id') id: string) {
     return this.salonsService.findAvailability(id);
+  }
+
+  @Get(':id/calendar')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(UserRole.OWNER)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get aggregated salon calendar (owner only)' })
+  @ApiResponse({ status: 200, description: 'Return salon calendar.' })
+  getCalendar(
+    @Param('id') id: string,
+    @Query('view') view: CalendarView = 'month',
+  ) {
+    const calendarView: CalendarView =
+      view === 'day' || view === 'week' || view === 'month' ? view : 'month';
+    return this.calendarService.getSalonCalendar(id, calendarView);
   }
 
   @Patch(':id')

--- a/src/salons/salons.module.ts
+++ b/src/salons/salons.module.ts
@@ -4,11 +4,18 @@ import { SalonsService } from './salons.service';
 import { SalonsController } from './salons.controller';
 import { Salon } from './entities/salon.entity';
 import { Service } from '../services/entities/service.entity';
+import { StaffModule } from '../staff/staff.module';
+import { AppointmentsModule } from '../appointments/appointments.module';
+import { CalendarService } from './calendar.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Salon, Service])],
+  imports: [
+    TypeOrmModule.forFeature([Salon, Service]),
+    StaffModule,
+    AppointmentsModule,
+  ],
   controllers: [SalonsController],
-  providers: [SalonsService],
-  exports: [SalonsService],
+  providers: [SalonsService, CalendarService],
+  exports: [SalonsService, CalendarService],
 })
 export class SalonsModule {}


### PR DESCRIPTION
## Summary
- add a CalendarService to gather staff schedules and appointments
- expose `/salons/:id/calendar` guarded by owner role
- wire calendar service in salons module

## Testing
- `npm test` *(fails: AppointmentsService.create expectation)*
- `npx tsc -p tsconfig.build.json`
- `npm run lint` *(fails with multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68440775e604832b819608055095d7d4