### PR TITLE
Add owner and staff guards

### DIFF
--- a/src/appointments/appointments.controller.ts
+++ b/src/appointments/appointments.controller.ts
@@ -19,6 +19,7 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { StaffGuard } from '../auth/guards/staff.guard';
 import { AccessTokenGuard } from '../auth/guards/access-token.guard';
 
 @ApiTags('appointments')
@@ -38,7 +39,7 @@ export class AppointmentsController {
   }
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), StaffGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get all appointments (salon only)' })
   @ApiResponse({ status: 200, description: 'Return all appointments.' })
@@ -56,7 +57,7 @@ export class AppointmentsController {
   }
 
   @Get(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), StaffGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get appointment by ID (salon only)' })
   @ApiResponse({ status: 200, description: 'Return the appointment.' })
@@ -66,7 +67,7 @@ export class AppointmentsController {
   }
 
   @Patch(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), StaffGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update appointment (salon only)' })
   @ApiResponse({

--- a/src/auth/guards/owner.guard.ts
+++ b/src/auth/guards/owner.guard.ts
@@ -1,0 +1,18 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { UserRole } from '../../shared/enums/user-role.enum';
+
+@Injectable()
+export class OwnerGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    if (!user || user.role !== UserRole.OWNER) {
+      return false;
+    }
+    const salonId = request.params.salonId || request.body?.salonId || request.params.id;
+    if (salonId && user.salonId && salonId !== user.salonId) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/auth/guards/staff.guard.ts
+++ b/src/auth/guards/staff.guard.ts
@@ -1,0 +1,22 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { UserRole } from '../../shared/enums/user-role.enum';
+
+@Injectable()
+export class StaffGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    if (!user || user.role !== UserRole.STAFF) {
+      return false;
+    }
+    const salonId = request.params.salonId || request.body?.salonId;
+    if (salonId && user.salonId && salonId !== user.salonId) {
+      return false;
+    }
+    const staffId = request.params.staffId;
+    if (staffId && staffId !== user.id) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/salons/salons.controller.ts
+++ b/src/salons/salons.controller.ts
@@ -19,6 +19,7 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { OwnerGuard } from '../auth/guards/owner.guard';
 
 @ApiTags('salons')
 @Controller('salons')
@@ -65,7 +66,7 @@ export class SalonsController {
   }
 
   @Patch(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OwnerGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update salon (salon owner only)' })
   @ApiResponse({ status: 200, description: 'Salon successfully updated.' })

--- a/src/services/services.controller.ts
+++ b/src/services/services.controller.ts
@@ -18,6 +18,7 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { OwnerGuard } from '../auth/guards/owner.guard';
 
 @ApiTags('services')
 @Controller('services')
@@ -25,7 +26,7 @@ export class ServicesController {
   constructor(private readonly servicesService: ServicesService) {}
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OwnerGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Create a new service (salon only)' })
   @ApiResponse({ status: 201, description: 'Service successfully created.' })
@@ -61,7 +62,7 @@ export class ServicesController {
   }
 
   @Patch(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OwnerGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update service (salon only)' })
   @ApiResponse({ status: 200, description: 'Service successfully updated.' })
@@ -71,7 +72,7 @@ export class ServicesController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OwnerGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete service (salon only)' })
   @ApiResponse({ status: 200, description: 'Service successfully deleted.' })

--- a/src/staff/staff.controller.ts
+++ b/src/staff/staff.controller.ts
@@ -18,6 +18,7 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { OwnerGuard } from '../auth/guards/owner.guard';
 
 @ApiTags('staff')
 @Controller('staff')
@@ -25,7 +26,7 @@ export class StaffController {
   constructor(private readonly staffService: StaffService) {}
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OwnerGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Create a new staff member (salon only)' })
   @ApiResponse({
@@ -38,7 +39,7 @@ export class StaffController {
   }
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OwnerGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get all staff members (salon only)' })
   @ApiResponse({ status: 200, description: 'Return all staff members.' })
@@ -47,7 +48,7 @@ export class StaffController {
   }
 
   @Get(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OwnerGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get staff member details (salon only)' })
   @ApiResponse({ status: 200, description: 'Return the staff member.' })
@@ -68,7 +69,7 @@ export class StaffController {
   }
 
   @Patch(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OwnerGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update staff member (salon only)' })
   @ApiResponse({
@@ -81,7 +82,7 @@ export class StaffController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OwnerGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete staff member (salon only)' })
   @ApiResponse({


### PR DESCRIPTION
## Summary
- add OwnerGuard and StaffGuard
- restrict staff, service, salon and appointment endpoints

## Testing
- `npm test` *(fails: AppointmentsService create test)*

------
https://chatgpt.com/codex/tasks/task_e_6844074196e0832ba2a1a968b624cc84