### PR TITLE
Add staff calendar endpoint with access guard

### DIFF
--- a/src/auth/guards/staff-calendar.guard.ts
+++ b/src/auth/guards/staff-calendar.guard.ts
@@ -1,0 +1,30 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { StaffService } from '../../staff/staff.service';
+import { UserRole } from '../../shared/enums/user-role.enum';
+
+@Injectable()
+export class StaffCalendarGuard implements CanActivate {
+  constructor(private readonly staffService: StaffService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const staffId = request.params.id;
+
+    if (!user) {
+      return false;
+    }
+
+    const staff = await this.staffService.findOne(staffId);
+
+    if (user.role === UserRole.OWNER && user.salonId === staff.salonId) {
+      return true;
+    }
+
+    if (user.role === UserRole.STAFF && user.id === staffId) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/staff/staff.controller.ts
+++ b/src/staff/staff.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import { StaffService } from './staff.service';
 import { CreateStaffDto } from './dto/create-staff.dto';
@@ -18,6 +19,7 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { StaffCalendarGuard } from '../auth/guards/staff-calendar.guard';
 
 @ApiTags('staff')
 @Controller('staff')
@@ -54,6 +56,19 @@ export class StaffController {
   @ApiResponse({ status: 404, description: 'Staff member not found.' })
   findOne(@Param('id') id: string) {
     return this.staffService.findOne(id);
+  }
+
+  @Get(':id/calendar')
+  @UseGuards(AuthGuard('jwt'), StaffCalendarGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get staff calendar' })
+  @ApiResponse({ status: 200, description: 'Return staff booked slots.' })
+  getCalendar(
+    @Param('id') id: string,
+    @Query('range') range: 'day' | 'week' | 'month' = 'day',
+    @Query('date') date: string,
+  ) {
+    return this.staffService.getBookedSlots(id, range, date);
   }
 
   @Get('salon/:salonId')

--- a/src/staff/staff.module.ts
+++ b/src/staff/staff.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { StaffService } from './staff.service';
 import { StaffController } from './staff.controller';
 import { Staff } from './entities/staff.entity';
+import { Appointment } from '../appointments/entities/appointment.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Staff])],
+  imports: [TypeOrmModule.forFeature([Staff, Appointment])],
   controllers: [StaffController],
   providers: [StaffService],
   exports: [StaffService],


### PR DESCRIPTION
## Summary
- extend `StaffService` with appointment queries
- import appointments in staff module
- guard calendar routes so only owners or the staff member can view
- expose `GET /staff/:id/calendar` endpoint

## Testing
- `npm run build`
- `npm test` *(fails: AppointmentsService spec expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68440775e364832b91626d8cef618ec1