### PR TITLE
Validate staff appointment data

### DIFF
--- a/src/appointments/appointments.module.ts
+++ b/src/appointments/appointments.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppointmentsService } from './appointments.service';
 import { AppointmentsController } from './appointments.controller';
 import { Appointment } from './entities/appointment.entity';
+import { Staff } from '../staff/entities';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Appointment])],
+  imports: [TypeOrmModule.forFeature([Appointment, Staff])],
   controllers: [AppointmentsController],
   providers: [AppointmentsService],
   exports: [AppointmentsService],


### PR DESCRIPTION
## Summary
- inject Staff repository into Appointments service
- validate staff existence, salon match and working hours when creating appointments
- prevent scheduling conflicts with existing appointments
- update Appointments module to load Staff entity
- extend appointment service unit tests for the new validations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68440774dc9c832b8596d999b2fee970