### PR TITLE
Implement salon metrics endpoint

### DIFF
--- a/src/salons/salons.controller.ts
+++ b/src/salons/salons.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import { SalonsService } from './salons.service';
 import { CalendarService, CalendarView } from './calendar.service';
+import { AnalyticsService, SalonMetrics } from '../analytics/analytics.service';
 import { CreateSalonDto } from './dto/create-salon.dto';
 import { UpdateSalonDto } from './dto/update-salon.dto';
 import {
@@ -32,6 +33,7 @@ export class SalonsController {
   constructor(
     private readonly salonsService: SalonsService,
     private readonly calendarService: CalendarService,
+    private readonly analyticsService: AnalyticsService,
   ) {}
 
   @Post()
@@ -96,6 +98,16 @@ export class SalonsController {
     const calendarView: CalendarView =
       view === 'day' || view === 'week' || view === 'month' ? view : 'month';
     return this.calendarService.getSalonCalendar(id, calendarView);
+  }
+
+  @Get(':id/metrics')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(UserRole.OWNER)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get analytics for a salon (owner only)' })
+  @ApiResponse({ status: 200, description: 'Return salon metrics.' })
+  getMetrics(@Param('id') id: string): Promise<SalonMetrics> {
+    return this.analyticsService.getSalonMetrics(id);
   }
 
   @Patch(':id')

--- a/src/staff/staff.module.ts
+++ b/src/staff/staff.module.ts
@@ -5,11 +5,12 @@ import { StaffController } from './staff.controller';
 import { Staff } from './entities/staff.entity';
 import { Appointment } from '../appointments/entities/appointment.entity';
 import { Service } from '../services/entities/service.entity';
+import { Salon } from '../salons/entities/salon.entity';
 import { AnalyticsService } from '../analytics/analytics.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Staff, Appointment, Service]),
+    TypeOrmModule.forFeature([Staff, Appointment, Service, Salon]),
   ],
   controllers: [StaffController],
   providers: [StaffService, AnalyticsService],


### PR DESCRIPTION
## Summary
- extend `AnalyticsService` with `getSalonMetrics` for appointment, revenue, and utilization calculations
- expose `GET /salons/:id/metrics` for owners
- include analytics service in salons controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee44e1198832b94547bf202fec87d