### PR TITLE
Add basic controller tests

### DIFF
--- a/src/appointments/appointments.controller.spec.ts
+++ b/src/appointments/appointments.controller.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppointmentsController } from './appointments.controller';
+import { AppointmentsService } from './appointments.service';
+import { CreateAppointmentDto } from './dto/create-appointment.dto';
+import { UpdateAppointmentDto } from './dto/update-appointment.dto';
+
+describe('AppointmentsController', () => {
+  let controller: AppointmentsController;
+  let service: jest.Mocked<AppointmentsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AppointmentsController],
+      providers: [
+        {
+          provide: AppointmentsService,
+          useValue: {
+            create: jest.fn(),
+            findAll: jest.fn(),
+            findByAccessToken: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AppointmentsController>(AppointmentsController);
+    service = module.get(AppointmentsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should create an appointment', async () => {
+    const dto = {} as CreateAppointmentDto;
+    (service.create as jest.Mock).mockResolvedValue('created');
+    await expect(controller.create(dto)).resolves.toBe('created');
+    expect(service.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('should return all appointments', async () => {
+    (service.findAll as jest.Mock).mockResolvedValue(['a']);
+    await expect(controller.findAll()).resolves.toEqual(['a']);
+    expect(service.findAll).toHaveBeenCalled();
+  });
+
+  it('should return appointment by access token', async () => {
+    (service.findByAccessToken as jest.Mock).mockResolvedValue('app');
+    await expect(controller.findByAccessToken('tok')).resolves.toBe('app');
+    expect(service.findByAccessToken).toHaveBeenCalledWith('tok');
+  });
+
+  it('should return appointment by id', async () => {
+    (service.findOne as jest.Mock).mockResolvedValue('app');
+    await expect(controller.findOne('1')).resolves.toBe('app');
+    expect(service.findOne).toHaveBeenCalledWith('1');
+  });
+
+  it('should update appointment', async () => {
+    const dto = {} as UpdateAppointmentDto;
+    (service.update as jest.Mock).mockResolvedValue('updated');
+    await expect(controller.update('1', dto)).resolves.toBe('updated');
+    expect(service.update).toHaveBeenCalledWith('1', dto);
+  });
+
+  it('should remove appointment', async () => {
+    (service.remove as jest.Mock).mockResolvedValue(undefined);
+    await expect(controller.remove('1', 'tok')).resolves.toBeUndefined();
+    expect(service.remove).toHaveBeenCalledWith('1');
+  });
+});

--- a/src/staff/staff.controller.spec.ts
+++ b/src/staff/staff.controller.spec.ts
@@ -1,0 +1,96 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StaffController } from './staff.controller';
+import { StaffService } from './staff.service';
+import { AnalyticsService } from '../analytics/analytics.service';
+import { CreateStaffDto } from './dto/create-staff.dto';
+import { UpdateStaffDto } from './dto/update-staff.dto';
+
+describe('StaffController', () => {
+  let controller: StaffController;
+  let staffService: jest.Mocked<StaffService>;
+  let analyticsService: jest.Mocked<AnalyticsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StaffController],
+      providers: [
+        {
+          provide: StaffService,
+          useValue: {
+            create: jest.fn(),
+            findAll: jest.fn(),
+            findOne: jest.fn(),
+            getBookedSlots: jest.fn(),
+            findBySalon: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+        {
+          provide: AnalyticsService,
+          useValue: {
+            getStaffMetrics: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<StaffController>(StaffController);
+    staffService = module.get(StaffService);
+    analyticsService = module.get(AnalyticsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should create staff', async () => {
+    const dto = {} as CreateStaffDto;
+    (staffService.create as jest.Mock).mockResolvedValue('created');
+    await expect(controller.create(dto)).resolves.toBe('created');
+    expect(staffService.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('should return all staff', async () => {
+    (staffService.findAll as jest.Mock).mockResolvedValue(['s']);
+    await expect(controller.findAll()).resolves.toEqual(['s']);
+    expect(staffService.findAll).toHaveBeenCalled();
+  });
+
+  it('should return staff by id', async () => {
+    (staffService.findOne as jest.Mock).mockResolvedValue('s');
+    await expect(controller.findOne('1')).resolves.toBe('s');
+    expect(staffService.findOne).toHaveBeenCalledWith('1');
+  });
+
+  it('should get calendar', async () => {
+    (staffService.getBookedSlots as jest.Mock).mockResolvedValue(['slot']);
+    await expect(controller.getCalendar('1', 'week', '2024-01-01')).resolves.toEqual(['slot']);
+    expect(staffService.getBookedSlots).toHaveBeenCalledWith('1', 'week', '2024-01-01');
+  });
+
+  it('should get metrics', async () => {
+    (analyticsService.getStaffMetrics as jest.Mock).mockResolvedValue({} as any);
+    await expect(controller.getMetrics('1')).resolves.toEqual({});
+    expect(analyticsService.getStaffMetrics).toHaveBeenCalledWith('1');
+  });
+
+  it('should find by salon', async () => {
+    (staffService.findBySalon as jest.Mock).mockResolvedValue(['s']);
+    await expect(controller.findBySalon('salon')).resolves.toEqual(['s']);
+    expect(staffService.findBySalon).toHaveBeenCalledWith('salon');
+  });
+
+  it('should update staff', async () => {
+    const dto = {} as UpdateStaffDto;
+    (staffService.update as jest.Mock).mockResolvedValue('u');
+    await expect(controller.update('1', dto)).resolves.toBe('u');
+    expect(staffService.update).toHaveBeenCalledWith('1', dto);
+  });
+
+  it('should remove staff', async () => {
+    (staffService.remove as jest.Mock).mockResolvedValue(undefined);
+    await expect(controller.remove('1')).resolves.toBeUndefined();
+    expect(staffService.remove).toHaveBeenCalledWith('1');
+  });
+});

--- a/test/appointments.e2e-spec.ts
+++ b/test/appointments.e2e-spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Appointments and Analytics (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('creates and cancels an appointment via token', async () => {
+    const createDto = {
+      salonId: '00000000-0000-0000-0000-000000000000',
+      serviceId: '00000000-0000-0000-0000-000000000000',
+      customerName: 'John',
+      customerPhone: '+15555555555',
+      date: '2025-01-01',
+      time: '10:00',
+    };
+
+    const createRes = await request(app.getHttpServer())
+      .post('/appointments')
+      .send(createDto);
+
+    const { id, accessToken } = createRes.body;
+    await request(app.getHttpServer())
+      .delete(`/appointments/${id}`)
+      .query({ token: accessToken })
+      .expect(200);
+  });
+
+  it('denies access to owner metrics without auth', () => {
+    return request(app.getHttpServer())
+      .get('/staff/1/metrics')
+      .expect(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for AppointmentsController
- add unit tests for StaffController
- add e2e tests for appointment flow and metrics

## Testing
- `npm test`
- `npm run test:e2e` *(fails: unable to connect to DB)*

------
https://chatgpt.com/codex/tasks/task_e_685ee455b9c8832b88a96bf4eeba55f6