### PR TITLE
Auto assign staff when creating appointment

### DIFF
--- a/src/appointments/appointments.module.ts
+++ b/src/appointments/appointments.module.ts
@@ -4,9 +4,10 @@ import { AppointmentsService } from './appointments.service';
 import { AppointmentsController } from './appointments.controller';
 import { Appointment } from './entities/appointment.entity';
 import { Staff } from '../staff/entities';
+import { StaffModule } from '../staff/staff.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Appointment, Staff])],
+  imports: [TypeOrmModule.forFeature([Appointment, Staff]), StaffModule],
   controllers: [AppointmentsController],
   providers: [AppointmentsService],
   exports: [AppointmentsService],

--- a/src/appointments/appointments.service.spec.ts
+++ b/src/appointments/appointments.service.spec.ts
@@ -5,12 +5,14 @@ import { AppointmentsService } from './appointments.service';
 import { Appointment } from './entities/appointment.entity';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { Staff } from '../staff/entities';
+import { StaffService } from '../staff/staff.service';
 import { AppointmentStatus } from '../shared/enums/appointment-status.enum';
 
 describe('AppointmentsService', () => {
   let service: AppointmentsService;
   let appointmentRepository: Repository<Appointment>;
   let staffRepository: Repository<Staff>;
+  let staffService: StaffService;
 
   const mockAppointment = {
     id: '1',
@@ -68,6 +70,11 @@ describe('AppointmentsService', () => {
     }),
   };
 
+  const mockStaffService = {
+    findBySalon: jest.fn(),
+    getBookedSlots: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -80,15 +87,20 @@ describe('AppointmentsService', () => {
           provide: getRepositoryToken(Staff),
           useValue: mockStaffRepository,
         },
+        {
+          provide: StaffService,
+          useValue: mockStaffService,
+        },
       ],
     }).compile();
 
     service = module.get<AppointmentsService>(AppointmentsService);
-    appointmentRepository = module.get<Repository<Appointment>>(
-      getRepositoryToken(Appointment),
-    );
-    staffRepository = module.get<Repository<Staff>>(getRepositoryToken(Staff));
-  });
+  appointmentRepository = module.get<Repository<Appointment>>(
+    getRepositoryToken(Appointment),
+  );
+  staffRepository = module.get<Repository<Staff>>(getRepositoryToken(Staff));
+  staffService = module.get<StaffService>(StaffService);
+});
 
   it('should be defined', () => {
     expect(service).toBeDefined();
@@ -191,6 +203,44 @@ describe('AppointmentsService', () => {
         serviceId: 'service-1',
         staffId: 'staff-1',
       };
+
+      await expect(service.create(dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should assign an available staff member when none is specified', async () => {
+      mockStaffService.findBySalon.mockResolvedValue([mockStaff]);
+      mockStaffService.getBookedSlots.mockResolvedValue([]);
+
+      const dto = {
+        customerName: 'John Doe',
+        customerPhone: '+1234567890',
+        date: '2024-03-20',
+        time: '14:30',
+        salonId: 'salon-1',
+        serviceId: 'service-1',
+      } as any;
+
+      const result = await service.create(dto);
+      expect(result.staffId).toBe('staff-1');
+      expect(appointmentRepository.create).toHaveBeenCalledWith({
+        ...dto,
+        staffId: 'staff-1',
+        accessToken: expect.any(String),
+      });
+    });
+
+    it('should throw BadRequestException if no staff is available', async () => {
+      mockStaffService.findBySalon.mockResolvedValue([mockStaff]);
+      mockStaffService.getBookedSlots.mockResolvedValue([mockAppointment]);
+
+      const dto = {
+        customerName: 'John Doe',
+        customerPhone: '+1234567890',
+        date: '2024-03-20',
+        time: '14:30',
+        salonId: 'salon-1',
+        serviceId: 'service-1',
+      } as any;
 
       await expect(service.create(dto)).rejects.toThrow(BadRequestException);
     });

--- a/src/appointments/appointments.service.ts
+++ b/src/appointments/appointments.service.ts
@@ -10,6 +10,7 @@ import { CreateAppointmentDto } from './dto/create-appointment.dto';
 import { UpdateAppointmentDto } from './dto/update-appointment.dto';
 import { v4 as uuidv4 } from 'uuid';
 import { Staff } from '../staff/entities';
+import { StaffService } from '../staff/staff.service';
 
 @Injectable()
 export class AppointmentsService {
@@ -18,12 +19,15 @@ export class AppointmentsService {
     private readonly appointmentRepository: Repository<Appointment>,
     @InjectRepository(Staff)
     private readonly staffRepository: Repository<Staff>,
+    private readonly staffService: StaffService,
   ) {}
 
   async create(
     createAppointmentDto: CreateAppointmentDto,
   ): Promise<Appointment> {
     const { staffId, salonId, date, time } = createAppointmentDto;
+
+    let selectedStaffId = staffId;
 
     if (staffId) {
       const staff = await this.staffRepository.findOne({ where: { id: staffId } });
@@ -64,6 +68,37 @@ export class AppointmentsService {
           'Staff already has an appointment at the requested time',
         );
       }
+    } else {
+      const staffMembers = await this.staffService.findBySalon(salonId);
+
+      for (const staff of staffMembers) {
+        const appointmentDay = new Date(date).toLocaleString('en-US', {
+          weekday: 'long',
+          timeZone: 'UTC',
+        });
+        const workingDay = staff.workingHours.find((wh) => wh.day === appointmentDay);
+
+        const withinWorkingHours =
+          workingDay?.slots.some((slot) => slot.start <= time && time < slot.end) ?? false;
+
+        if (!withinWorkingHours) {
+          continue;
+        }
+
+        const booked = await this.staffService.getBookedSlots(staff.id, 'day', date);
+
+        const hasConflict = booked.some((b) => b.time === time);
+
+        if (!hasConflict) {
+          selectedStaffId = staff.id;
+          break;
+        }
+      }
+
+      if (!selectedStaffId) {
+        throw new BadRequestException('No available staff at the requested time');
+      }
+      createAppointmentDto.staffId = selectedStaffId;
     }
 
     const appointment = this.appointmentRepository.create({


### PR DESCRIPTION
## Summary
- inject `StaffModule` into appointments module
- enhance appointment creation to auto-select an available staff member when none is provided
- update unit tests for new behaviour

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ee44db140832b8dc8c943a38812f9