### PR TITLE
Add userId to Staff entity

### DIFF
--- a/src/auth/guards/staff-calendar.guard.ts
+++ b/src/auth/guards/staff-calendar.guard.ts
@@ -21,7 +21,7 @@ export class StaffCalendarGuard implements CanActivate {
       return true;
     }
 
-    if (user.role === UserRole.STAFF && user.id === staffId) {
+    if (user.role === UserRole.STAFF && user.id === staff.userId) {
       return true;
     }
 

--- a/src/database/migrations/1715000001000-AddUserIdToStaff.ts
+++ b/src/database/migrations/1715000001000-AddUserIdToStaff.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserIdToStaff1715000001000 implements MigrationInterface {
+  name = 'AddUserIdToStaff1715000001000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "staff" ADD "userId" uuid`);
+    await queryRunner.query(
+      `ALTER TABLE "staff" ADD CONSTRAINT "FK_staff_user" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "staff" DROP CONSTRAINT "FK_staff_user"`,
+    );
+    await queryRunner.query(`ALTER TABLE "staff" DROP COLUMN "userId"`);
+  }
+}

--- a/src/staff/dto/create-staff.dto.ts
+++ b/src/staff/dto/create-staff.dto.ts
@@ -5,6 +5,7 @@ import {
   IsArray,
   ValidateNested,
   IsUUID,
+  IsOptional,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { WeeklyAvailability } from '../../shared/classes/weekly-availability.class';
@@ -34,4 +35,13 @@ export class CreateStaffDto {
   @IsUUID()
   @IsNotEmpty()
   salonId: string;
+
+  @ApiProperty({
+    example: 'usr1a2b3-c4d5-e6f7-g8h9-i0j1k2l3m4n5',
+    description: 'ID of the user associated with this staff member',
+    required: false,
+  })
+  @IsUUID()
+  @IsOptional()
+  userId?: string;
 }

--- a/src/staff/entities/staff.entity.ts
+++ b/src/staff/entities/staff.entity.ts
@@ -12,6 +12,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Salon } from '../../salons/entities/salon.entity';
 import { WeeklyAvailability } from '../../shared/types/weekly-availability.type';
 import { Appointment } from '../../appointments/entities/appointment.entity';
+import { User } from '../../users/entities/user.entity';
 
 @Entity('staff')
 export class Staff {
@@ -29,6 +30,14 @@ export class Staff {
   @Column('uuid')
   salonId: string;
 
+  @ApiProperty({
+    example: 'usr1a2b3-c4d5-e6f7-g8h9-i0j1k2l3m4n5',
+    description: 'ID of the user associated with this staff member',
+    required: false,
+  })
+  @Column('uuid', { nullable: true })
+  userId?: string;
+
   @ApiProperty({ example: 'John Doe', description: 'Name of the staff member' })
   @Column()
   name: string;
@@ -42,6 +51,10 @@ export class Staff {
   @ManyToOne(() => Salon, (salon) => salon.staff, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'salonId' })
   salon: Salon;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'userId' })
+  user?: User;
 
   @OneToMany(() => Appointment, (appointment) => appointment.staff)
   appointments: Appointment[];


### PR DESCRIPTION
## Summary
- allow owners to specify a user when creating staff
- store user ID on staff record
- validate calendars using staff.userId
- create migration adding the new column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee436e42c832b99ed3ab066d0c64b