### PR TITLE
Add salon search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ Once the application is running, you can access the Swagger documentation at:
 http://localhost:3000/api
 ```
 
+## API Reference
+
+### `GET /salons`
+
+Retrieve a paginated list of salons. Supports filtering by name, sorting and pagination.
+
+**Query Parameters**
+
+- `name` (string, optional) – filter salons by partial name match.
+- `sortBy` (string, optional, default `createdAt`) – field to sort by (`name` or `createdAt`).
+- `sortOrder` (string, optional, default `ASC`) – sort direction (`ASC` or `DESC`).
+- `page` (number, optional, default `1`) – page number starting from 1.
+- `limit` (number, optional, default `10`) – number of items per page.
+
+**Example**
+
+```http
+GET /salons?name=studio&sortBy=name&sortOrder=DESC&page=2&limit=5
+```
+
 ## Testing
 
 Run unit tests:

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -43,7 +43,7 @@ export class AdminController {
   @ApiOperation({ summary: 'Get all salons (admin only)' })
   @ApiResponse({ status: 200, description: 'Return all salons.' })
   findAllSalons() {
-    return this.salonsService.findAll();
+    return this.salonsService.findAll({});
   }
 
   @Delete('users/:id')

--- a/src/database/seeds/create-sample-data.seed.ts
+++ b/src/database/seeds/create-sample-data.seed.ts
@@ -4,6 +4,7 @@ import { User } from '../../users/entities/user.entity';
 import { Staff } from '../../staff/entities/staff.entity';
 import { UserRole } from '../../shared/enums/user-role.enum';
 import * as bcrypt from 'bcrypt';
+import { DayOfWeek } from '../../shared/enums/days-of-week.enum';
 
 export async function createSampleData(dataSource: DataSource) {
   const salonRepo = dataSource.getRepository(Salon);
@@ -11,11 +12,11 @@ export async function createSampleData(dataSource: DataSource) {
   const staffRepo = dataSource.getRepository(Staff);
 
   const defaultAvailability = [
-    { day: 'Monday', slots: [{ start: '09:00', end: '17:00' }] },
-    { day: 'Tuesday', slots: [{ start: '09:00', end: '17:00' }] },
-    { day: 'Wednesday', slots: [{ start: '09:00', end: '17:00' }] },
-    { day: 'Thursday', slots: [{ start: '09:00', end: '17:00' }] },
-    { day: 'Friday', slots: [{ start: '09:00', end: '17:00' }] },
+    { day: DayOfWeek.MONDAY, slots: [{ start: '09:00', end: '17:00' }] },
+    { day: DayOfWeek.TUESDAY, slots: [{ start: '09:00', end: '17:00' }] },
+    { day: DayOfWeek.WEDNESDAY, slots: [{ start: '09:00', end: '17:00' }] },
+    { day: DayOfWeek.THURSDAY, slots: [{ start: '09:00', end: '17:00' }] },
+    { day: DayOfWeek.FRIDAY, slots: [{ start: '09:00', end: '17:00' }] },
   ];
 
   const salonsData = [

--- a/src/salons/dto/list-salons.dto.ts
+++ b/src/salons/dto/list-salons.dto.ts
@@ -1,0 +1,42 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsInt, Min, IsIn, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ListSalonsDto {
+  @ApiPropertyOptional({ description: 'Filter salons by name (partial match)' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Field to sort by',
+    enum: ['name', 'createdAt'],
+    default: 'createdAt',
+  })
+  @IsOptional()
+  @IsIn(['name', 'createdAt'])
+  sortBy?: 'name' | 'createdAt' = 'createdAt';
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    enum: ['ASC', 'DESC'],
+    default: 'ASC',
+  })
+  @IsOptional()
+  @IsIn(['ASC', 'DESC'])
+  sortOrder?: 'ASC' | 'DESC' = 'ASC';
+
+  @ApiPropertyOptional({ description: 'Page number', default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 10;
+}

--- a/src/salons/salons.controller.spec.ts
+++ b/src/salons/salons.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { SalonsController } from './salons.controller';
 import { SalonsService } from './salons.service';
 import { CalendarService } from './calendar.service';
+import { AnalyticsService } from '../analytics/analytics.service';
 
 describe('SalonsController', () => {
   let controller: SalonsController;
@@ -15,6 +16,7 @@ describe('SalonsController', () => {
       providers: [
         { provide: SalonsService, useValue: mockSalonsService },
         { provide: CalendarService, useValue: {} },
+        { provide: AnalyticsService, useValue: {} },
       ],
     }).compile();
 

--- a/src/salons/salons.controller.ts
+++ b/src/salons/salons.controller.ts
@@ -15,6 +15,7 @@ import { CalendarService, CalendarView } from './calendar.service';
 import { AnalyticsService, SalonMetrics } from '../analytics/analytics.service';
 import { CreateSalonDto } from './dto/create-salon.dto';
 import { UpdateSalonDto } from './dto/update-salon.dto';
+import { ListSalonsDto } from './dto/list-salons.dto';
 import {
   ApiTags,
   ApiOperation,
@@ -46,9 +47,9 @@ export class SalonsController {
 
   @Get()
   @ApiOperation({ summary: 'Get all salons (public)' })
-  @ApiResponse({ status: 200, description: 'Return all salons.' })
-  findAll() {
-    return this.salonsService.findAll();
+  @ApiResponse({ status: 200, description: 'Return salons with pagination.' })
+  findAll(@Query() query: ListSalonsDto) {
+    return this.salonsService.findAll(query);
   }
 
   @Get('me')

--- a/src/salons/salons.service.spec.ts
+++ b/src/salons/salons.service.spec.ts
@@ -26,6 +26,14 @@ describe('SalonsService', () => {
     weeklyAvailability: [],
   };
 
+  const mockQueryBuilder: any = {
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn().mockResolvedValue([[mockSalon], 1]),
+  };
+
   const mockSalonRepository = {
     create: jest.fn().mockImplementation((dto) => dto),
     save: jest
@@ -39,6 +47,7 @@ describe('SalonsService', () => {
     }),
     find: jest.fn().mockResolvedValue([mockSalon]),
     remove: jest.fn().mockResolvedValue(true),
+    createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
   };
 
   const mockServicesRepository = {
@@ -110,9 +119,9 @@ describe('SalonsService', () => {
   });
 
   describe('findAll', () => {
-    it('should return an array of salons', async () => {
-      const result = await service.findAll();
-      expect(result).toEqual([mockSalon]);
+    it('should return paginated salons', async () => {
+      const result = await service.findAll({});
+      expect(result).toEqual({ data: [mockSalon], total: 1, page: 1, limit: 10 });
     });
   });
 


### PR DESCRIPTION
## Summary
- enable pagination, sorting and name filter for salons
- document new `/salons` query options
- fix seeds for DayOfWeek enum
- update tests for new `findAll` behaviour

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fbc6424d8832b8cef16d42c54f7ad